### PR TITLE
added a debug sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,15 @@ Icon
 *.sublime-project
 .idea/*
 
-
 # Node
 node_modules
 
 # Grunt
 .grunt/
+
+# compiled code
+dist/*
+
+# Debugging Files
+debug/*
+!debug/sample.html

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=utf-8 />
+    <title>Simple FeatureLayer</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+    <!-- Load Leaflet from CDN-->
+    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+    <script src="../node_modules/leaflet/dist/leaflet.js"></script>
+
+    <script src="../dist/leaflet-shape-markers.js"></script>
+    <style>
+      body {margin:0;padding:0;}
+      #map {position: absolute;top:0;bottom:0;right:0;left:0;}
+    </style>
+  </head>
+  <body>
+
+    <div id="map"></div>
+
+    <script>
+      /*
+      make a copy of this file in the same folder if you'd like git to ignore your local changes
+      */
+      var map = L.map('map').setView([45.526, -122.667], 13)
+
+      L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map)
+
+      L.ShapeMarkers.xMarker([45.505264141298525, -122.691707611084], 50).addTo(map)
+
+      L.ShapeMarkers.crossMarker([45.5469954685617, -122.69840240478517], 50, {
+        color: 'red'
+      }).addTo(map)
+
+      L.ShapeMarkers.squareMarker([45.49515737901887, -122.6450157165], 50, {
+        weight: 10,
+        color: 'green'
+      }).addTo(map)
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
added a sample which shows how to implement the plugin w/o esri services.  once this gets into `master` we can create and sync `gh-pages` and update the readme with a screenshot.

fyi, i don't have push access to this repo.  probably easiest to just add all of @Esri/leaflet-contributors 
