### PR TITLE
fix case for filenames and html use of library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Take a look at the [live demo](http://esri.github.io/Leaflet.shapeMarkers/).
 ![Example Image](https://raw.github.com/Esri/Leaflet.shapeMarkers/master/example.png)
 
 ```js
-L.ShapeMarkers.xMarker([45.5052, -122.6917], 50).addTo(map)
+L.shapeMarkers.xMarker([45.5052, -122.6917], 50).addTo(map)
 ```
 **Leaflet.shapeMarkers targets Leaflet 1.0.x**
 

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -29,13 +29,13 @@
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       }).addTo(map)
 
-      L.ShapeMarkers.xMarker([45.505264141298525, -122.691707611084], 50).addTo(map)
+      L.shapeMarkers.xMarker([45.505264141298525, -122.691707611084], 50).addTo(map)
 
-      L.ShapeMarkers.crossMarker([45.5469954685617, -122.69840240478517], 50, {
+      L.shapeMarkers.crossMarker([45.5469954685617, -122.69840240478517], 50, {
         color: 'red'
       }).addTo(map)
 
-      L.ShapeMarkers.squareMarker([45.49515737901887, -122.6450157165], 50, {
+      L.shapeMarkers.squareMarker([45.49515737901887, -122.6450157165], 50, {
         weight: 10,
         color: 'green'
       }).addTo(map)

--- a/index.html
+++ b/index.html
@@ -28,13 +28,13 @@
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       }).addTo(map)
 
-      L.ShapeMarkers.xMarker([45.5052, -122.6917], 50).addTo(map)
+      L.shapeMarkers.xMarker([45.5052, -122.6917], 50).addTo(map)
 
-      L.ShapeMarkers.crossMarker([45.5470, -122.6984], 50, {
+      L.shapeMarkers.crossMarker([45.5470, -122.6984], 50, {
         color: 'red'
       }).addTo(map)
 
-      L.ShapeMarkers.squareMarker([45.4952, -122.6450], 50, {
+      L.shapeMarkers.squareMarker([45.4952, -122.6450], 50, {
         weight: 10,
         color: 'green'
       }).addTo(map)

--- a/src/CrossMarker.js
+++ b/src/CrossMarker.js
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import { ShapeMarker } from './shapeMarker';
+import { ShapeMarker } from './ShapeMarker';
 
 export var CrossMarker = ShapeMarker.extend({
 

--- a/src/DiamondMarker.js
+++ b/src/DiamondMarker.js
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import { ShapeMarker } from './shapeMarker';
+import { ShapeMarker } from './ShapeMarker';
 
 export var DiamondMarker = ShapeMarker.extend({
   options: {

--- a/src/SquareMarker.js
+++ b/src/SquareMarker.js
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import { ShapeMarker } from './shapeMarker';
+import { ShapeMarker } from './ShapeMarker';
 
 export var SquareMarker = ShapeMarker.extend({
   options: {

--- a/src/XMarker.js
+++ b/src/XMarker.js
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import { ShapeMarker } from './shapeMarker';
+import { ShapeMarker } from './ShapeMarker';
 
 export var XMarker = ShapeMarker.extend({
 


### PR DESCRIPTION
@jgravois, travis wasn't passing on esri-leaflet-renderers because of the imports not matching the case of the file.  I fixed up a few other cases while I was at it.  We should probably put out another release for our linux friends.
