### PR TITLE
add comment for semistandard to ignore karma and leaflet globals

### DIFF
--- a/spec/CrossMarkerSpec.js
+++ b/spec/CrossMarkerSpec.js
@@ -1,3 +1,4 @@
+/* global describe it expect beforeEach L */
 describe('CrossMarker', function () {
   describe('#_size', function () {
     var map;

--- a/spec/DiamondMarkerSpec.js
+++ b/spec/DiamondMarkerSpec.js
@@ -1,3 +1,4 @@
+/* global describe it expect beforeEach L */
 describe('DiamondMarker', function () {
   describe('#_size', function () {
     var map;

--- a/spec/SquareMarkerSpec.js
+++ b/spec/SquareMarkerSpec.js
@@ -1,3 +1,4 @@
+/* global describe it expect beforeEach L */
 describe('SquareMarker', function () {
   describe('#_size', function () {
     var map;

--- a/spec/XMarkerSpec.js
+++ b/spec/XMarkerSpec.js
@@ -1,3 +1,4 @@
+/* global describe it expect beforeEach L */
 describe('XMarker', function () {
   describe('#_size', function () {
     var map;


### PR DESCRIPTION
Fix for all the 'not defined errors' when running semistandard on spec folder
