### PR TITLE
pkg.main should point at built output, not raw ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "watch": "^0.17.1"
   },
   "homepage": "http://github.com/Esri/Leaflet.shapeMarkers",
+  "module": "src/ShapeMarkers.js",
   "jsnext:main": "src/ShapeMarkers.js",
   "jspm": {
     "registry": "npm",
@@ -39,7 +40,7 @@
   },
   "keywords": ["Leaflet", "GIS", "Esri"],
   "license": "Apache-2.0",
-  "main": "src/ShapeMarkers.js",
+  "main": "dist/leaflet-shape-markers.js",
   "readmeFilename": "README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref: https://github.com/rollup/rollup/wiki/pkg.module

> Tools such as rollup-plugin-node-resolve and Webpack 2 treat `jsnext:main` and `module` interchangeably. They're the same thing, except that `module` is more likely to become standardised.)

> `pkg.module` will point to a module that has `ES2015 module syntax` but otherwise `only syntax features that node supports`.

`main` on the other hand, needs to point at the compiled output.  the way we have it now is a problem for nifty CDNs like: https://unpkg.com/leaflet-shape-markers@1.0.5