### PR TITLE
Fix issue with import when using webpack 5

### DIFF
--- a/src/ShapeMarkers.js
+++ b/src/ShapeMarkers.js
@@ -1,6 +1,6 @@
 import packageInfo from '../package.json';
-
-export const VERSION = packageInfo.version
+var version = packageInfo.version;
+export { version as VERSION };
 
 export { crossMarker } from './CrossMarker';
 export { xMarker } from './XMarker';

--- a/src/ShapeMarkers.js
+++ b/src/ShapeMarkers.js
@@ -1,4 +1,6 @@
-export {version as VERSION} from '../package.json';
+import packageInfo from '../package.json';
+
+export const VERSION = packageInfo.version
 
 export { crossMarker } from './CrossMarker';
 export { xMarker } from './XMarker';


### PR DESCRIPTION
When using this package with `webpack@5.x.x` I am getting the following error:
```sh
ERROR in ./node_modules/leaflet-shape-markers/src/ShapeMarkers.js 1:0-51
Should not import the named export 'version' (reexported as 'VERSION') from default-exporting module (only default export is available soon)
 @ ./node_modules/esri-leaflet-renderers/src/Symbols/PointSymbol.js 8:0-90 146:15-27 148:15-28 150:15-26 152:15-22
 @ ./node_modules/esri-leaflet-renderers/src/Renderers/Renderer.js 3:0-49 41:13-24
 @ ./node_modules/esri-leaflet-renderers/src/Renderers/ClassBreaksRenderer.js
```

It seems that "soon" webpack will not allow named export from import.

The suggested fix shouldn't break anything as it just changed the way things are imported and then exported.

I encountered such a case when using [L.esri.WebMap](https://github.com/ynunokawa/L.esri.WebMap).